### PR TITLE
Cache validator public keys for given era

### DIFF
--- a/src/Lachain.Core/Blockchain/Validators/ValidatorManager.cs
+++ b/src/Lachain.Core/Blockchain/Validators/ValidatorManager.cs
@@ -13,7 +13,7 @@ namespace Lachain.Core.Blockchain.Validators
     {
         private readonly ISnapshotIndexRepository _snapshotIndexRepository;
         private static readonly ILogger<ValidatorManager> Logger = LoggerFactory.GetLoggerForClass<ValidatorManager>();
-        private static Dictionary<long, IReadOnlyCollection<ECDSAPublicKey>> _pubkeyCache = new Dictionary<long, IReadOnlyCollection<ECDSAPublicKey>>();
+        private readonly Dictionary<long, IReadOnlyCollection<ECDSAPublicKey>> _pubkeyCache = new Dictionary<long, IReadOnlyCollection<ECDSAPublicKey>>();
 
         public ValidatorManager(ISnapshotIndexRepository snapshotIndexRepository)
         {


### PR DESCRIPTION
Optimize ValidatorManager::GetValidatorsPublicKeys. This function is called from GetValidatorForEra and GetValudatorIndex and takes a lot of time. The values it returns are not changed with time,  so we can store them in memory to have quick access.

Please see to the Dictionary object declaration,  Is it valid to make it static in this situation?