### PR TITLE
Fix the system txes verification condition

### DIFF
--- a/src/Lachain.Core/Blockchain/Operations/TransactionManager.cs
+++ b/src/Lachain.Core/Blockchain/Operations/TransactionManager.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using Lachain.Core.Blockchain.Error;
 using Lachain.Core.Blockchain.Interface;
 using Lachain.Core.Blockchain.SystemContracts;
+using Lachain.Core.Blockchain.SystemContracts.ContractManager;
 using Lachain.Core.Blockchain.VM;
 using Lachain.Crypto;
 using Lachain.Proto;
@@ -57,14 +58,13 @@ namespace Lachain.Core.Blockchain.Operations
             var indexInCycle = block.Header.Index % StakingContract.CycleDuration;
             var cycle = block.Header.Index / StakingContract.CycleDuration;
 
-            var lastTxInBlockIndex = block.TransactionHashes.Count - 1;
             var canTransactionMissVerification =
                 block.Header.Index == 0 ||
                 cycle > 0 && indexInCycle == StakingContract.AttendanceDetectionDuration &&
-                (int) receipt.IndexInBlock == lastTxInBlockIndex ||
+                receipt.Transaction.To.Equals(ContractRegisterer.StakingContract) ||
                 indexInCycle == StakingContract.VrfSubmissionPhaseDuration &&
-                (int) receipt.IndexInBlock == lastTxInBlockIndex ||
-                cycle > 0 && indexInCycle == 0 && (int) receipt.IndexInBlock == lastTxInBlockIndex;
+                receipt.Transaction.To.Equals(ContractRegisterer.StakingContract) ||
+                cycle > 0 && indexInCycle == 0 && receipt.Transaction.To.Equals(ContractRegisterer.GovernanceContract);
 
             var verifyError = VerifyInternal(receipt, canTransactionMissVerification);
             if (verifyError != OperatingError.Ok)


### PR DESCRIPTION
It fixes the issue with invalid state hash for new block during the mass send of the invalid transactions. 

The root cause of this error was the fact that during block emulation the system tx with VRF Submission was not the last tx in the block and its execution fails with InvalidSignature error,  while during real block execution this was the only tx in the block (wrong txes were skipped) and was executed successfully,  so we get different state after execution. 

It is a narrow solution for this exact case,  I think we should formulate some common strategy for system transactions verification in the future.