### PR TITLE
made some changes to run the tests successfully in windows machine

### DIFF
--- a/test/Lachain.CoreTest/IntegrationTests/BlocksTest.cs
+++ b/test/Lachain.CoreTest/IntegrationTests/BlocksTest.cs
@@ -40,9 +40,26 @@ namespace Lachain.CoreTest.IntegrationTests
         private IPrivateWallet _wallet = null!;
         private IContainer? _container;
 
+        public BlocksTest()
+        {
+           var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
+                Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
+                new RunOptions()
+            ));
+
+            containerBuilder.RegisterModule<BlockchainModule>();
+            containerBuilder.RegisterModule<ConfigModule>();
+            containerBuilder.RegisterModule<StorageModule>();
+
+            _container = containerBuilder.Build();
+
+        } 
+
         [SetUp]
         public void Setup()
         {
+            _container?.Dispose() ;
+            TestUtils.DeleteTestChainData();
             var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
                 Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
                 new RunOptions()
@@ -55,14 +72,14 @@ namespace Lachain.CoreTest.IntegrationTests
             _stateManager = _container.Resolve<IStateManager>();
             _wallet = _container.Resolve<IPrivateWallet>();
             _transactionPool = _container.Resolve<ITransactionPool>();
-            TestUtils.DeleteTestChainData();
+
         }
 
         [TearDown]
         public void Teardown()
         {
-            TestUtils.DeleteTestChainData();
             _container?.Dispose();
+            TestUtils.DeleteTestChainData();
         }
 
         [Test]

--- a/test/Lachain.CoreTest/IntegrationTests/ContractTests.cs
+++ b/test/Lachain.CoreTest/IntegrationTests/ContractTests.cs
@@ -90,8 +90,8 @@ namespace Lachain.CoreTest.IntegrationTests
         [TearDown]
         public void Teardown()
         {
-            TestUtils.DeleteTestChainData();
             _container?.Dispose();
+            TestUtils.DeleteTestChainData();
         }
 
         [Test]

--- a/test/Lachain.CoreTest/IntegrationTests/GovernanceEventsTests.cs
+++ b/test/Lachain.CoreTest/IntegrationTests/GovernanceEventsTests.cs
@@ -47,9 +47,25 @@ namespace Lachain.CoreTest.IntegrationTests
         private IContainer? _container;
         private Dictionary<UInt256, ByteString> _eventData = null!;
 
+        public GovernanceEventsTest()
+        {
+            var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
+                Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
+                new RunOptions()
+            ));
+
+            containerBuilder.RegisterModule<BlockchainModule>();
+            containerBuilder.RegisterModule<ConfigModule>();
+            containerBuilder.RegisterModule<StorageModule>();
+
+            _container = containerBuilder.Build();
+
+        } 
+
         [SetUp]
         public void Setup()
         {
+            _container?.Dispose();
             TestUtils.DeleteTestChainData();
             _eventData = new Dictionary<UInt256, ByteString>();
             var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
@@ -70,8 +86,8 @@ namespace Lachain.CoreTest.IntegrationTests
         [TearDown]
         public void Teardown()
         {
-            TestUtils.DeleteTestChainData();
             _container?.Dispose();
+            TestUtils.DeleteTestChainData();
         }
 
         [Test]

--- a/test/Lachain.CoreTest/IntegrationTests/ValidatorStatusTests.cs
+++ b/test/Lachain.CoreTest/IntegrationTests/ValidatorStatusTests.cs
@@ -38,9 +38,24 @@ namespace Lachain.CoreTest.IntegrationTests
         private IValidatorStatusManager _validatorStatusManager = null!;
         private IContainer? _container;
 
+        public ValidatorStatusTest()
+        {
+            var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
+                Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
+                new RunOptions()
+            ));
+
+            containerBuilder.RegisterModule<BlockchainModule>();
+            containerBuilder.RegisterModule<ConfigModule>();
+            containerBuilder.RegisterModule<StorageModule>();
+
+            _container = containerBuilder.Build();
+        }
+
         [SetUp]
         public void Setup()
         {
+            _container?.Dispose();
             TestUtils.DeleteTestChainData();
             var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
                 Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
@@ -64,8 +79,8 @@ namespace Lachain.CoreTest.IntegrationTests
         [TearDown]
         public void Teardown()
         {
-            TestUtils.DeleteTestChainData();
             _container?.Dispose();
+            TestUtils.DeleteTestChainData();
         }
         
         // TODO: this is not working since we have only 1 validator

--- a/test/Lachain.CoreTest/IntegrationTests/VirtualMachineTest.cs
+++ b/test/Lachain.CoreTest/IntegrationTests/VirtualMachineTest.cs
@@ -18,7 +18,7 @@ namespace Lachain.CoreTest.IntegrationTests
 {
     public class VirtualMachineTest
     {
-        private readonly IContainer _container;
+        private IContainer? _container;
 
         public VirtualMachineTest()
         {
@@ -37,20 +37,33 @@ namespace Lachain.CoreTest.IntegrationTests
         [SetUp]
         public void Setup()
         {
+            _container?.Dispose();
             TestUtils.DeleteTestChainData();
+
+            var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
+                Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
+                new RunOptions()
+            ));
+
+            containerBuilder.RegisterModule<BlockchainModule>();
+            containerBuilder.RegisterModule<ConfigModule>();
+            containerBuilder.RegisterModule<StorageModule>();
+
+            _container = containerBuilder.Build();
         }
 
         [TearDown]
         public void Teardown()
         {
+            _container?.Dispose();
             TestUtils.DeleteTestChainData();
-            _container.Dispose();
+         //   _container.Dispose();
         }
 
         [Test]
         public void Test_VirtualMachine_InvokeContract()
         {
-            var stateManager = _container.Resolve<IStateManager>();
+            var stateManager = _container?.Resolve<IStateManager>();
             var tx = new TransactionReceipt();
             
             var sender = "0x6bc32575acb8754886dc283c2c8ac54b1bd93195".HexToBytes().ToUInt160();

--- a/test/Lachain.StorageTest/StorageIntergrationTest.cs
+++ b/test/Lachain.StorageTest/StorageIntergrationTest.cs
@@ -15,7 +15,7 @@ namespace Lachain.StorageTest
 {
     public class StorageTest
     {
-        private readonly IContainer _container;
+        private IContainer _container;
 
         public StorageTest()
         {
@@ -36,12 +36,25 @@ namespace Lachain.StorageTest
         [SetUp]
         public void Setup()
         {
+            _container.Dispose();
             TestUtils.DeleteTestChainData();
+
+            var containerBuilder = new SimpleInjectorContainerBuilder(new ConfigManager(
+                Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "config.json"),
+                new RunOptions()
+            ));
+
+            containerBuilder.RegisterModule<BlockchainModule>();
+            containerBuilder.RegisterModule<ConfigModule>();
+            containerBuilder.RegisterModule<StorageModule>();
+
+            _container = containerBuilder.Build();
         }
 
         [TearDown]
         public void Teardown()
         {
+            _container.Dispose();
             TestUtils.DeleteTestChainData();
         }
 

--- a/test/Lachain.UtilityTest/TestUtils.cs
+++ b/test/Lachain.UtilityTest/TestUtils.cs
@@ -9,7 +9,6 @@ using Lachain.Proto;
 using Lachain.Utility;
 using Lachain.Utility.Utils;
 using Nethereum.Util;
-using System.Diagnostics;
 
 
 namespace Lachain.UtilityTest
@@ -39,7 +38,7 @@ namespace Lachain.UtilityTest
         public static void DeleteTestChainData()
         {
             var chainTest = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ChainTest");
-            if (Directory.Exists(chainTest))  Directory.Delete(chainTest, true);
+            if (Directory.Exists(chainTest)) Directory.Delete(chainTest, true);
             Directory.CreateDirectory(chainTest);
             var chainTest2 = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ChainTest2");
             if (Directory.Exists(chainTest2)) Directory.Delete(chainTest2, true);

--- a/test/Lachain.UtilityTest/TestUtils.cs
+++ b/test/Lachain.UtilityTest/TestUtils.cs
@@ -9,6 +9,8 @@ using Lachain.Proto;
 using Lachain.Utility;
 using Lachain.Utility.Utils;
 using Nethereum.Util;
+using System.Diagnostics;
+
 
 namespace Lachain.UtilityTest
 {
@@ -37,7 +39,7 @@ namespace Lachain.UtilityTest
         public static void DeleteTestChainData()
         {
             var chainTest = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ChainTest");
-            if (Directory.Exists(chainTest)) Directory.Delete(chainTest, true);
+            if (Directory.Exists(chainTest))  Directory.Delete(chainTest, true);
             Directory.CreateDirectory(chainTest);
             var chainTest2 = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ChainTest2");
             if (Directory.Exists(chainTest2)) Directory.Delete(chainTest2, true);

--- a/test/Lachain.UtilityTest/TestUtils.cs
+++ b/test/Lachain.UtilityTest/TestUtils.cs
@@ -10,7 +10,6 @@ using Lachain.Utility;
 using Lachain.Utility.Utils;
 using Nethereum.Util;
 
-
 namespace Lachain.UtilityTest
 {
     public class TestUtils


### PR DESCRIPTION
Lachain.CoreTest and Lachain.StorageTest were failing, as _container.Dispose() was not placed properly in some files
. So when TestUtils.DeleteTestChainData() was called, a file(LOCK) was still open in the process and errors occurred. Tweaked positions of these two methods in some files. Now Lachain.StorageTest runs properly but Lachain.CoreTest sometime runs properly and sometime 4/5 tests crash among 16 tests.