### PR TITLE
fixed folding logic in case of deletion to remove unnecessary long branch

### DIFF
--- a/src/Lachain.Storage/Trie/TrieHashMap.cs
+++ b/src/Lachain.Storage/Trie/TrieHashMap.cs
@@ -157,6 +157,8 @@ namespace Lachain.Storage.Trie
                 }
             }
 
+            if(value!=0 && node.GetChildByHash(h) != 0 && node.Children.Count()==1 && GetNodeById(value).Type == NodeType.Leaf ) return value ;
+
             var modified = InternalNode.ModifyChildren(
                 node, h, value,
                 node.Children.Select(id => GetNodeById(id)?.Hash ?? throw new InvalidOperationException()),


### PR DESCRIPTION
In case of deletion, if a node have two child then and one child is deleted and other one is leaf, then we folded this node. But consider it's parent, if that node have only one child, it should be also removed/folded.