### PR TITLE
Use height as blockstamp in scripts external handler

### DIFF
--- a/src/Lachain.Core/Blockchain/VM/ExternalHandler.cs
+++ b/src/Lachain.Core/Blockchain/VM/ExternalHandler.cs
@@ -784,13 +784,7 @@ namespace Lachain.Core.Blockchain.VM
             var snapshot = frame.InvocationContext.Snapshot;
             var blockHeight = snapshot.Blocks.GetTotalBlockHeight();
             
-            // Get block at the given height
-            var block = snapshot.Blocks.GetBlockByHeight(blockHeight);
-            
-            // Get block's timestamp
-            if (block is null)
-                throw new InvalidContractException("Bad call to (get_block_timestamp)");
-            var timeStamp = block.Timestamp;
+            var timeStamp = blockHeight;
             
             // Load timestamp at the given dataOffset
             var result = SafeCopyToMemory(frame.Memory, timeStamp.ToBytes().ToArray(), dataOffset);


### PR DESCRIPTION
In our blockchain blocks can has different blockstamps on different nodes,  so we use height as a universal time measure in scripts