### PR TITLE
Optimized Pool Repository and Fixed Some bugs

### DIFF
--- a/src/Lachain.Console/Application.cs
+++ b/src/Lachain.Console/Application.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using Lachain.Core.Blockchain.Interface;
 using Lachain.Core.Blockchain.Validators;
+using Lachain.Core.Blockchain.Pool;
 using Lachain.Core.CLI;
 using Lachain.Core.Config;
 using Lachain.Core.Consensus;
@@ -79,6 +80,7 @@ namespace Lachain.Console
             var NodeRetrieval = _container.Resolve<INodeRetrieval>();
             var dbContext = _container.Resolve<IRocksDbContext>();
             var storageManager = _container.Resolve<IStorageManager>();
+            var transactionPool = _container.Resolve<ITransactionPool>();
 
             // set chainId from config
             var chainId = configManager.GetConfig<NetworkConfig>("network")?.ChainId;
@@ -143,7 +145,10 @@ namespace Lachain.Console
             networkManager.Start();
             transactionVerifier.Start();
             commandManager.Start(wallet.EcdsaKeyPair);
-            
+
+            // pending transactions are restored from pool repository to in-memory storage
+            // it's important to restore pool after transactionVerifier and before blockSynchronizer starts
+            transactionPool.Restore();
 
             blockSynchronizer.Start();
             Logger.LogInformation("Synchronizing blocks...");

--- a/src/Lachain.Core/Blockchain/Pool/TransactionPool.cs
+++ b/src/Lachain.Core/Blockchain/Pool/TransactionPool.cs
@@ -61,6 +61,8 @@ namespace Lachain.Core.Blockchain.Pool
             {
                 Delete(txHash);
             }
+            _poolRepository.RemoveTransactions(e.TransactionHashes);
+            SanitizePool();
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
@@ -166,6 +168,29 @@ namespace Lachain.Core.Blockchain.Pool
                 );
             }
         }
+
+
+        private void SanitizePool()
+        {
+            var txHashes = _poolRepository.GetTransactionPool();
+            var txToRemove = new List<UInt256>();
+            foreach(var txHash in txHashes)
+            {
+                var tx = _poolRepository.GetTransactionByHash(txHash);
+                if(tx is null) 
+                    continue;
+                if(!TxNonceValid(tx))
+                    txToRemove.Add(txHash);
+            }
+            int txRemovedCount = _poolRepository.RemoveTransactions(txToRemove);
+            
+            if(txRemovedCount > 0) 
+            {
+                Logger.LogTrace($"Sanitized transaction pool; dropped {txRemovedCount} txs from pool repository");
+            }
+        }
+
+        
 
         private void RemoveTxes(IReadOnlyCollection<TransactionReceipt> txes)
         {

--- a/src/Lachain.Core/Blockchain/Pool/TransactionPool.cs
+++ b/src/Lachain.Core/Blockchain/Pool/TransactionPool.cs
@@ -50,7 +50,6 @@ namespace Lachain.Core.Blockchain.Pool
             _relayQueue = new HashSet<TransactionReceipt>();
 
             _blockManager.OnBlockPersisted += OnBlockPersisted;
-            Restore();
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Lachain.Storage/Repositories/IPoolRepository.cs
+++ b/src/Lachain.Storage/Repositories/IPoolRepository.cs
@@ -36,6 +36,9 @@ namespace Lachain.Storage.Repositories
         /// </summary>
         /// <param name="txHash"></param>
         /// <returns></returns>
+
+        int RemoveTransactions(IEnumerable<UInt256> txHashes);
+
         bool ContainsTransactionByHash(UInt256 txHash);
     }
 }

--- a/src/Lachain.Storage/Repositories/PoolRepository.cs
+++ b/src/Lachain.Storage/Repositories/PoolRepository.cs
@@ -29,7 +29,7 @@ namespace Lachain.Storage.Repositories
         public ICollection<UInt256> GetTransactionPool()
         {
             var raw = _rocksDbContext.Get(EntryPrefix.TransactionPool.BuildPrefix());
-            return raw == null ? new List<UInt256>() : raw.ToMessageArray<UInt256>();
+            return raw == null ? new List<UInt256>() : raw.ByteArrayToTransactionHashList();
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
@@ -39,10 +39,10 @@ namespace Lachain.Storage.Repositories
             var raw = _rocksDbContext.Get(EntryPrefix.TransactionPool.BuildPrefix());
             if (raw == null)
                 return false;
-            var pool = raw.ToMessageArray<UInt256>();
+            var pool = raw.ByteArrayToTransactionHashList();
             if (!pool.Remove(txHash))
                 return false;
-            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), pool.ToByteArray());
+            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), pool.TransactionHashListToByteArray());
             /* remove transaction from storage */
             _rocksDbContext.Delete(EntryPrefix.TransactionByHash.BuildPrefix(txHash));
             return true;
@@ -67,7 +67,7 @@ namespace Lachain.Storage.Repositories
                     txRemoved.Add(txHash);
             }
             
-            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), newPool.ToByteArray());
+            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), newPool.TransactionHashListToByteArray());
 
             foreach(var txHash in txRemoved)
                 _rocksDbContext.Delete(EntryPrefix.TransactionByHash.BuildPrefix(txHash));
@@ -84,11 +84,11 @@ namespace Lachain.Storage.Repositories
             _rocksDbContext.Save(prefixTx, transaction.ToByteArray());
             /* add transaction to pool */
             var raw = _rocksDbContext.Get(EntryPrefix.TransactionPool.BuildPrefix());
-            var pool = raw != null ? raw.ToMessageArray<UInt256>() : new List<UInt256>();
+            var pool = raw != null ? raw.ByteArrayToTransactionHashList() : new List<UInt256>();
             if (pool.Contains(transaction.Hash))
                 return;
             pool.Add(transaction.Hash);
-            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), pool.ToByteArray());
+            _rocksDbContext.Save(EntryPrefix.TransactionPool.BuildPrefix(), pool.TransactionHashListToByteArray());
         }
         
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Lachain.Utility/Utils/ProtoUtils.cs
+++ b/src/Lachain.Utility/Utils/ProtoUtils.cs
@@ -19,7 +19,11 @@ namespace Lachain.Utility.Utils
                 var arrayOf = values as T[] ?? values.ToArray();
                 writer.WriteLength(arrayOf.Length);
                 foreach (var value in arrayOf)
-                    writer.Write(value.ToByteArray());
+                {
+                    var valueByteArray = value.ToByteArray();
+                    writer.WriteLength(valueByteArray.Length);
+                    writer.Write(valueByteArray);
+                }
                 writer.Flush();
                 return stream.ToArray();
             }
@@ -48,7 +52,8 @@ namespace Lachain.Utility.Utils
                 var parser = new MessageParser<T>(() => new T());
                 for (var i = 0UL; i < length; i++)
                 {
-                    var el = parser.ParseFrom(stream);
+                    var msgLen = (int) reader.ReadLength();
+                    var el = parser.ParseFrom(reader.ReadBytes(msgLen));
                     result.Add(el);
                 }
 

--- a/src/Lachain.Utility/Utils/ProtoUtils.cs
+++ b/src/Lachain.Utility/Utils/ProtoUtils.cs
@@ -29,6 +29,21 @@ namespace Lachain.Utility.Utils
             }
         }
         
+        public static byte[] TransactionHashListToByteArray(this IEnumerable<UInt256> values)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                var arrayOf = values.ToArray();
+                writer.WriteLength(arrayOf.Length);
+                foreach (var value in arrayOf)
+                    writer.Write(value.ToByteArray());
+                
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
         public static string ParsedObject(object obj)
         {
             var parsedObject = "";
@@ -54,6 +69,24 @@ namespace Lachain.Utility.Utils
                 {
                     var msgLen = (int) reader.ReadLength();
                     var el = parser.ParseFrom(reader.ReadBytes(msgLen));
+                    result.Add(el);
+                }
+
+                return result;
+            }
+        }
+
+        public static ICollection<UInt256> ByteArrayToTransactionHashList(this byte[] buffer, ulong limit = ulong.MaxValue)
+        {
+            using (var stream = new MemoryStream(buffer))
+            using (var reader = new BinaryReader(stream))
+            {
+                var length = reader.ReadLength(limit);
+                var result = new List<UInt256>();
+                var parser = new MessageParser<UInt256>(() => new UInt256());
+                for (var i = 0UL; i < length; i++)
+                {
+                    var el = parser.ParseFrom(reader.ReadBytes(34));
                     result.Add(el);
                 }
 


### PR DESCRIPTION
(1) In previous implementation, transaction was never deleted from pool repository. It was fixed by this way: Once a block is persisted, we iterate over all the transaction in the pool and it is deleted if (a) the block contains this tx, or (b) it's nonce has become invalid. 

(2) Encoding and decoding of list of transactionHash (UInt256 in protobuf) was buggy. The main issue is that, when we pass stream in parser in ToMessageArray of ProtoUtils.cs, it immediately reads till the end of the stream. To overcome this, we only pass next 34 bytes to the parser each time. 

(3) In TransactionPool.cs, Restore() is called in the constructor.  Restore() uses transactionVerifier and transactionManager. But this may not be created yet during the execution of Restore(). So, this method was called from Application.Cs once transactionVerifier and transactionManager are created. Also, it's necessary that Restore() executes before BlockSynchronizer. Because Once a block is persisted, it may remove some of the restored transactions. 
