### PR TITLE
Catch excedption for unknown tx hash in block

### DIFF
--- a/src/Lachain.Core/Network/BlockSynchronizer.cs
+++ b/src/Lachain.Core/Network/BlockSynchronizer.cs
@@ -157,7 +157,7 @@ namespace Lachain.Core.Network
                     }
                     catch (Exception e)
                     {
-                        Logger.LogWarning("Failed to get transaction receipts for tx hash");
+                        Logger.LogWarning($"Failed to get transaction receipts for tx hash: {e}");
                     }
 
                     return false;

--- a/src/Lachain.Core/Network/BlockSynchronizer.cs
+++ b/src/Lachain.Core/Network/BlockSynchronizer.cs
@@ -147,10 +147,19 @@ namespace Lachain.Core.Network
 
                 if (!block.TransactionHashes.ToHashSet().SetEquals(receipts.Select(r => r.Hash)))
                 {
-                    var needHashes = string.Join(", ", block.TransactionHashes.Select(x => x.ToHex()));
-                    var gotHashes = string.Join(", ", receipts.Select(x => x.Hash.ToHex()));
-                    Logger.LogTrace(
-                        $"Skipped block {block.Header.Index} from peer {publicKey.ToHex()}: expected hashes [{needHashes}] got hashes [{gotHashes}]");
+                    try
+                    {
+                        var needHashes = string.Join(", ", block.TransactionHashes.Select(x => x.ToHex()));
+                        var gotHashes = string.Join(", ", receipts.Select(x => x.Hash.ToHex()));
+
+                        Logger.LogTrace(
+                            $"Skipped block {block.Header.Index} from peer {publicKey.ToHex()}: expected hashes [{needHashes}] got hashes [{gotHashes}]");
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogWarning("Failed to get transaction receipts for tx hash");
+                    }
+
                     return false;
                 }
 


### PR DESCRIPTION
This catch is added for the case when handler knows tx hash  but can't get tx receipt for it.