### PR TITLE
Hardfork3

### DIFF
--- a/src/Lachain.Core/Blockchain/Hardfork/HardforkConfig.cs
+++ b/src/Lachain.Core/Blockchain/Hardfork/HardforkConfig.cs
@@ -6,5 +6,6 @@ namespace Lachain.Core.Blockchain.Hardfork
     {
         [JsonProperty("hardfork_1")] public ulong? Hardfork_1 { get; set; }
         [JsonProperty("hardfork_2")] public ulong? Hardfork_2 { get; set; }
+        [JsonProperty("hardfork_3")] public ulong? Hardfork_3 { get; set; }
     }
 }

--- a/src/Lachain.Core/Blockchain/Hardfork/HardforkHeights.cs
+++ b/src/Lachain.Core/Blockchain/Hardfork/HardforkHeights.cs
@@ -7,6 +7,7 @@ namespace Lachain.Core.Blockchain.Hardfork
         private static bool alreadySet;
         private static ulong Hardfork_1;
         private static ulong Hardfork_2;
+        private static ulong Hardfork_3;
 
         public static bool IsHardfork_1Active(ulong height)
         {
@@ -16,6 +17,11 @@ namespace Lachain.Core.Blockchain.Hardfork
         public static bool IsHardfork_2Active(ulong height)
         {
             return height >= Hardfork_2;
+        }
+
+        public static bool IsHardfork_3Active(ulong height)
+        {
+            return height >= Hardfork_3;
         }
 
         public static void SetHardforkHeights(HardforkConfig hardforkConfig)
@@ -32,6 +38,11 @@ namespace Lachain.Core.Blockchain.Hardfork
             if(hardforkConfig.Hardfork_2 is null)
                 throw new Exception("hardfork_2 is null");
             Hardfork_2 = (ulong) hardforkConfig.Hardfork_2;
+            
+            if(hardforkConfig.Hardfork_3 is null)
+                throw new Exception("hardfork_3 is null");
+            Hardfork_3 = (ulong) hardforkConfig.Hardfork_3;
+
         }
     }
 }

--- a/src/Lachain.Core/Blockchain/SystemContracts/DeployContract.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/DeployContract.cs
@@ -173,12 +173,12 @@ namespace Lachain.Core.Blockchain.SystemContracts
         }
 
         [ContractMethod(DeployInterface.MethodSetDeployHeight)]
-        public ExecutionStatus SetDeployHeight(UInt160 contractAddress, UInt256 height, SystemContractExecutionFrame frame)
+        public ExecutionStatus SetDeployHeight(UInt160 contractAddress, byte[] height, SystemContractExecutionFrame frame)
         {
             try
             {
                 if(HardforkHeights.IsHardfork_3Active(frame.InvocationContext.Snapshot.Blocks.GetTotalBlockHeight()))
-                    _deployHeight.SetValue(contractAddress.ToBytes(), height.ToBytes().ToArray());
+                    _deployHeight.SetValue(contractAddress.ToBytes(), height.ToArray());
             }
             catch (Exception e)
             {

--- a/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
@@ -6,7 +6,7 @@ namespace Lachain.Core.Blockchain.SystemContracts.Interface
     {
         public const string MethodDeploy = "deploy(bytes)";
         public const string MethodGetDeployHeight = "getDeployHeight(address)";
-        public const string MethodSetDeployHeight = "setDeployHeight(address, uint256)";
+        public const string MethodSetDeployHeight = "setDeployHeight(address, bytes)";
         
         public string[] Methods { get; } =
         {

--- a/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
@@ -5,10 +5,12 @@ namespace Lachain.Core.Blockchain.SystemContracts.Interface
     public class DeployInterface : IContractInterface
     {
         public const string MethodDeploy = "deploy(bytes)";
+        public const string MethodGetDeployHeight = "getDEployGeight(uint256)";
         
         public string[] Methods { get; } =
         {
             MethodDeploy,
+            MethodGetDeployHeight
         };
 
         public string[] Properties { get; } =

--- a/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/Interface/DeployInterface.cs
@@ -5,12 +5,14 @@ namespace Lachain.Core.Blockchain.SystemContracts.Interface
     public class DeployInterface : IContractInterface
     {
         public const string MethodDeploy = "deploy(bytes)";
-        public const string MethodGetDeployHeight = "getDEployGeight(uint256)";
+        public const string MethodGetDeployHeight = "getDeployHeight(address)";
+        public const string MethodSetDeployHeight = "setDeployHeight(address, uint256)";
         
         public string[] Methods { get; } =
         {
             MethodDeploy,
-            MethodGetDeployHeight
+            MethodGetDeployHeight,
+            MethodSetDeployHeight
         };
 
         public string[] Properties { get; } =


### PR DESCRIPTION
Smartcontract-related hardforks  applies to the smart-contracts based on their deploy height,  not the current chain height. If some contract deploy another contract,  its deploy height should be equal to its parent deploy height,