### PR TITLE
Fix attendance after the break in validator status

### DIFF
--- a/src/Lachain.Consensus/ValidatorAttendance.cs
+++ b/src/Lachain.Consensus/ValidatorAttendance.cs
@@ -110,7 +110,7 @@ namespace Lachain.Consensus
             if (previousCycle == currentCycle - 1 && currentAsNext)
                 return new ValidatorAttendance(currentCycle, nextAttendanceDict, new Dictionary<string, ulong>());
 
-            return new ValidatorAttendance(previousCycle, new Dictionary<string, ulong>(),
+            return new ValidatorAttendance(currentCycle, new Dictionary<string, ulong>(),
                 new Dictionary<string, ulong>());
         }
 


### PR DESCRIPTION
The issue arises after the node was validator for some time and stored Attendance info in database,  than it stopped to be validator for some time,  and when it becomes validator again it can't load correct Attendance object,  the object it gets can't be changed with the data from the current cycle