### PR TITLE
Change signature algorithm for private API methods

### DIFF
--- a/src/Lachain.Core/RPC/HTTP/HttpService.cs
+++ b/src/Lachain.Core/RPC/HTTP/HttpService.cs
@@ -152,7 +152,7 @@ namespace Lachain.Core.RPC.HTTP
                 var requestObj = (JObject)item;
                 if(requestObj == null) return false;
 
-                if(!_CheckAuth(requestObj, signature, timestamp))
+                if(!_CheckAuth(requestObj, context, signature, timestamp))
                 {
                     var error = new JObject
                     {
@@ -178,7 +178,7 @@ namespace Lachain.Core.RPC.HTTP
             return true;
         }
 
-        private bool _CheckAuth(JObject body, string signature, string timestamp)
+        private bool _CheckAuth(JObject body, HttpListenerContext context, string signature, string timestamp)
         {
             if(context.Request.IsLocal) return true;
 

--- a/src/Lachain.Core/RPC/HTTP/HttpService.cs
+++ b/src/Lachain.Core/RPC/HTTP/HttpService.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json.Linq;
 using Lachain.Logger;
 using Lachain.Utility.Utils;
 using Secp256k1Net;
-using Newtonsoft.Json;
 
 namespace Lachain.Core.RPC.HTTP
 {
@@ -26,7 +25,7 @@ namespace Lachain.Core.RPC.HTTP
                 {
                     _Worker(rpcConfig);
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     Console.Error.WriteLine(e);
                 }
@@ -54,21 +53,21 @@ namespace Lachain.Core.RPC.HTTP
 
         private void _Worker(RpcConfig rpcConfig)
         {
-            if (!HttpListener.IsSupported)
+            if(!HttpListener.IsSupported)
                 throw new Exception("Your platform doesn't support [HttpListener]");
             _httpListener = new HttpListener();
-            foreach (var host in rpcConfig.Hosts ?? throw new InvalidOperationException())
+            foreach(var host in rpcConfig.Hosts ?? throw new InvalidOperationException())
                 _httpListener.Prefixes.Add($"http://{host}:{rpcConfig.Port}/");
             _httpListener.AuthenticationSchemes = AuthenticationSchemes.Anonymous;
             _apiKey = rpcConfig.ApiKey ?? throw new InvalidOperationException();
             _httpListener.Start();
-            while (_httpListener.IsListening)
+            while(_httpListener.IsListening)
             {
                 try
                 {
                     _Handle(_httpListener.GetContext());
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     Console.Error.WriteLine(e);
                 }
@@ -84,7 +83,7 @@ namespace Lachain.Core.RPC.HTTP
             var sigs = request.Headers.GetValues("Signature");
             var sig = string.Empty;
 
-            if (sigs != null && sigs.Length > 0)
+            if(sigs != null && sigs.Length > 0)
             {
                 sig = sigs[0];
             }
@@ -92,12 +91,11 @@ namespace Lachain.Core.RPC.HTTP
             Logger.LogInformation($"{request.HttpMethod}");
             var response = context.Response;
             /* check is request options pre-flight */
-            if (request.HttpMethod == "OPTIONS")
+            if(request.HttpMethod == "OPTIONS")
             {
-
-                if (request.Headers["Origin"] != null)
+                if(request.Headers["Origin"] != null)
                 {
-                    response.AddHeader("Access-Control-Allow-Origin", request.Headers["Origin"]);
+                    response.AddHeader("Access-Control-Allow-Origin", request.Headers["Origin"]!);
                 }
                 response.AddHeader("Access-Control-Allow-Headers", "*");
                 response.AddHeader("Access-Control-Allow-Methods", "GET, POST");
@@ -111,18 +109,18 @@ namespace Lachain.Core.RPC.HTTP
             Logger.LogInformation($"Body: [{body}]");
             var isArray = body.StartsWith("[");
 
-            if (request.Headers["Origin"] != null)
-                response.AddHeader("Access-Control-Allow-Origin", request.Headers["Origin"]);
+            if(request.Headers["Origin"] != null)
+                response.AddHeader("Access-Control-Allow-Origin", request.Headers["Origin"]!);
             response.Headers.Add("Access-Control-Allow-Methods", "POST, GET");
             response.Headers.Add("Access-Control-Allow-Credentials", "true");
             var rpcResultHandler = new AsyncCallback(result =>
             {
-                if (!(result is JsonRpcStateAsync jsonRpcStateAsync))
+                if(!(result is JsonRpcStateAsync jsonRpcStateAsync))
                     return;
 
                 var resultString = jsonRpcStateAsync.Result;
 
-                if (isArray && !jsonRpcStateAsync.Result.StartsWith("["))
+                if(isArray && !jsonRpcStateAsync.Result.StartsWith("["))
                     resultString = "[" + resultString + "]";
 
                 var output = Encoding.UTF8.GetBytes(resultString);
@@ -138,10 +136,10 @@ namespace Lachain.Core.RPC.HTTP
 
             var requests = isArray ? JArray.Parse(body) : new JArray { JObject.Parse(body) };
 
-            foreach (var item in requests)
+            foreach(var item in requests)
             {
                 var requestObj = (JObject)item;
-                if (!_CheckAuth(requestObj, context, sig, body))
+                if(!_CheckAuth(requestObj, context, sig, body))
                 {
                     var error = new JObject
                     {
@@ -155,7 +153,7 @@ namespace Lachain.Core.RPC.HTTP
                         ["id"] = ulong.Parse(requestObj["id"]!.ToString()),
                     };
                     var output = Encoding.UTF8.GetBytes(res.ToString());
-                    Logger.LogInformation($"output: [{res.ToString()}]");
+                    Logger.LogInformation($"output: [{res}]");
                     response.OutputStream.Write(output, 0, output.Length);
                     response.OutputStream.Flush();
                     response.Close();
@@ -169,20 +167,22 @@ namespace Lachain.Core.RPC.HTTP
 
         private bool _CheckAuth(JObject body, HttpListenerContext context, string sig, string bodyPlainText)
         {
-            if (context.Request.IsLocal) return true;
+            if(context.Request.IsLocal) return true;
 
-            if (_privateMethods.Contains(body["method"]!.ToString()))
+            if(_privateMethods.Contains(body["method"]!.ToString()))
             {
-                if (string.IsNullOrEmpty(sig))
+                if(string.IsNullOrEmpty(sig))
                 {
                     return false;
                 }
 
-                var messageBytes = Encoding.UTF8.GetBytes(bodyPlainText);
+                string method = body["method"]!.ToString();
+
+                var messageBytes = Encoding.UTF8.GetBytes(string.Join(",", new string[] { method, bodyPlainText }));
                 var messageHash = System.Security.Cryptography.SHA256.Create().ComputeHash(messageBytes);
 
                 var signature = sig.HexToBytes();
-                var public_key = _apiKey.HexToBytes();
+                var public_key = _apiKey!.HexToBytes();
 
                 var secp256K1 = new Secp256k1();
                 return secp256K1.Verify(signature, messageHash, public_key);

--- a/src/Lachain.Core/RPC/HTTP/HttpService.cs
+++ b/src/Lachain.Core/RPC/HTTP/HttpService.cs
@@ -180,7 +180,7 @@ namespace Lachain.Core.RPC.HTTP
 
         private bool _CheckAuth(JObject body, string signature, string timestamp)
         {
-            //if(context.Request.IsLocal) return true;
+            if(context.Request.IsLocal) return true;
 
             if(_privateMethods.Contains(body["method"]!.ToString()))
             {


### PR DESCRIPTION
Now we sign request body as a whole,  but it is not safe,  body contains spaces,  tabs,  line breaks, and other symbols that can be added or removed during transfer from client to the server. We should construct some string whose format will be predefined in hex view,  smth like this - https://api.latoken.com/doc/v2/#section/Authorization/Signature,  as an example we can use 'method' + "args,  separated with commas"