### PR TITLE
hotfix for validator_stop call

### DIFF
--- a/src/Lachain.Core/RPC/HTTP/HttpService.cs
+++ b/src/Lachain.Core/RPC/HTTP/HttpService.cs
@@ -39,7 +39,8 @@ namespace Lachain.Core.RPC.HTTP
         private readonly List<string> _privateMethods = new List<string>
         {
             "validator_start",
-            "validator_stop",
+            // TODO: remove this comment after the working auth
+            //"validator_stop",
             "fe_sendTransaction",
             "deleteTransactionPoolRepository",
             "clearInMemoryPool",


### PR DESCRIPTION
It is safe because this call requires unlocked wallet now and protected with wallet password