### PR TITLE
Fix stake info in fe_balance and fe_account

### DIFF
--- a/src/Lachain.Core/Blockchain/Interface/ISystemContractReader.cs
+++ b/src/Lachain.Core/Blockchain/Interface/ISystemContractReader.cs
@@ -4,17 +4,19 @@ namespace Lachain.Core.Blockchain.Interface
 {
     public interface ISystemContractReader
     {
-        UInt256 GetStake(UInt160? stakerAddress = null);
-
-        UInt256 GetPenalty(UInt160? stakerAddress = null);
+        UInt256 GetStake(UInt160? stakedAddress = null);
+        
+        UInt256 GetStakerTotalStake(UInt160? stakedAddress = null);
+        
+        UInt256 GetPenalty(UInt160? stakedAddress = null);
 
         UInt256 GetTotalStake();
 
         byte[] GetVrfSeed();
 
-        int GetWithdrawRequestCycle(UInt160? stakerAddress = null);
+        int GetWithdrawRequestCycle(UInt160? stakedAddress = null);
 
-        bool IsNextValidator(byte[]? stakerPublicKey = null);
+        bool IsNextValidator(byte[]? stakedPublicKey = null);
 
         bool IsVrfSubmissionPhase();
 
@@ -22,13 +24,13 @@ namespace Lachain.Core.Blockchain.Interface
 
         bool IsKeyGenPhase();
 
-        bool IsCheckedIn(byte[]? stakerAddress = null);
+        bool IsCheckedIn(byte[]? stakedAddress = null);
 
-        bool IsPreviousValidator(byte[]? stakerPublicKey = null);
+        bool IsPreviousValidator(byte[]? stakedPublicKey = null);
 
         byte[][] GetPreviousValidators();
 
-        bool IsAbleToBeValidator(UInt160? stakerAddress = null);
+        bool IsAbleToBeValidator(UInt160? stakedAddress = null);
 
         UInt160 NodeAddress();
 

--- a/src/Lachain.Core/Blockchain/SystemContracts/Interface/StakingInterface.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/Interface/StakingInterface.cs
@@ -22,6 +22,7 @@ namespace Lachain.Core.Blockchain.SystemContracts.Interface
         public const string MethodGetPreviousValidators = "getPreviousValidators()";
         public const string MethodIsPreviousValidator = "isPreviousValidator(bytes)";
         public const string MethodIsCheckedInAttendanceDetection = "isCheckedInAttendanceDetection(bytes)";
+        public const string MethodGetStakerTotalStake = "getStakerTotalStake(address)";
         
         public string[] Methods { get; } =
         {
@@ -40,6 +41,7 @@ namespace Lachain.Core.Blockchain.SystemContracts.Interface
             MethodSubmitAttendanceDetection,
             MethodGetPreviousValidators,
             MethodIsPreviousValidator,
+            MethodGetStakerTotalStake
         };
 
         public string[] Properties { get; } =

--- a/src/Lachain.Core/Blockchain/SystemContracts/Utils/SystemContractReader.cs
+++ b/src/Lachain.Core/Blockchain/SystemContracts/Utils/SystemContractReader.cs
@@ -61,20 +61,29 @@ namespace Lachain.Core.Blockchain.SystemContracts.Utils
             return (ulong) rawValue.ToUInt256().ToBigInteger();
         }
 
-        public UInt256 GetStake(UInt160? stakerAddress = null)
+        public UInt256 GetStake(UInt160? stakedAddress = null)
+        {
+            stakedAddress ??= _nodeAddress;
+            var invResult = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetStake,
+                stakedAddress);
+
+            return invResult.ToUInt256();
+        }
+
+        public UInt256 GetStakerTotalStake(UInt160? stakerAddress = null)
         {
             stakerAddress ??= _nodeAddress;
-            var invResult = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetStake,
+            var invResult = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetStakerTotalStake,
                 stakerAddress);
 
             return invResult.ToUInt256();
         }
 
-        public UInt256 GetPenalty(UInt160? stakerAddress = null)
+        public UInt256 GetPenalty(UInt160? stakedAddress = null)
         {
-            stakerAddress ??= _nodeAddress;
+            stakedAddress ??= _nodeAddress;
             var invResult = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetPenalty,
-                stakerAddress);
+                stakedAddress);
 
             return invResult.ToUInt256();
         }
@@ -90,27 +99,27 @@ namespace Lachain.Core.Blockchain.SystemContracts.Utils
             return ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetVrfSeed);
         }
 
-        public int GetWithdrawRequestCycle(UInt160? stakerAddress = null)
+        public int GetWithdrawRequestCycle(UInt160? stakedAddress = null)
         {
-            stakerAddress ??= _nodeAddress;
+            stakedAddress ??= _nodeAddress;
             var res = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodGetWithdrawRequestCycle,
-                stakerAddress);
+                stakedAddress);
             return res.Length > 0 ? BitConverter.ToInt32(res): 0;
         }
 
 
 
-        public bool IsNextValidator(byte[]? stakerPublicKey = null)
+        public bool IsNextValidator(byte[]? stakedPublicKey = null)
         {
-            stakerPublicKey ??= _nodePublicKey;
+            stakedPublicKey ??= _nodePublicKey;
             if (IsVrfSubmissionPhase())
             {
                 var isNextValidatorStaking = ReadSystemContractData(ContractRegisterer.StakingContract, StakingInterface.MethodIsNextValidator,
-                    stakerPublicKey);
+                    stakedPublicKey);
                 return !isNextValidatorStaking.ToUInt256().IsZero();
             }
             var isNextValidatorGovernance = ReadSystemContractData(ContractRegisterer.GovernanceContract, GovernanceInterface.MethodIsNextValidator,
-                stakerPublicKey);
+                stakedPublicKey);
             
             return !isNextValidatorGovernance.ToUInt256().IsZero();
         }

--- a/src/Lachain.Core/RPC/HTTP/FrontEnd/FrontEndService.cs
+++ b/src/Lachain.Core/RPC/HTTP/FrontEnd/FrontEndService.cs
@@ -57,14 +57,16 @@ namespace Lachain.Core.RPC.HTTP.FrontEnd
             var balance =
                 _stateManager.LastApprovedSnapshot.Balances.GetBalance(addressUint160);
 
-            var stake = _systemContractReader.GetStake(addressUint160).ToMoney();
+            var staked = _systemContractReader.GetStake(addressUint160).ToMoney();
+            var staking = _systemContractReader.GetStakerTotalStake(addressUint160).ToMoney();
             var penalty = _systemContractReader.GetPenalty(addressUint160).ToMoney();
             var nonce = _stateManager.LastApprovedSnapshot.Transactions.GetTotalTransactionCount(
                 addressUint160);
             return new JObject
             {
                 ["balance"] = balance.ToString(),
-                ["stake"] = stake.ToString(),
+                ["staked"] = staked.ToString(),
+                ["staking"] = staking.ToString(),
                 ["penalty"] = penalty.ToString(),
                 ["nonce"] = nonce,
             };

--- a/src/Lachain.Core/RPC/HTTP/FrontEnd/FrontEndService.cs
+++ b/src/Lachain.Core/RPC/HTTP/FrontEnd/FrontEndService.cs
@@ -87,8 +87,8 @@ namespace Lachain.Core.RPC.HTTP.FrontEnd
             var balance =
                 _stateManager.LastApprovedSnapshot.Balances.GetBalance(addressUint160);
 
-            var stake = _systemContractReader.GetStake(addressUint160).ToMoney().ToWei() /
-                        StakingContract.TokenUnitsInRoll;
+            var staked = _systemContractReader.GetStake(addressUint160).ToMoney();
+            var staking = _systemContractReader.GetStakerTotalStake(addressUint160).ToMoney();
             var penalty = _systemContractReader.GetPenalty(addressUint160).ToMoney();
             var isCurrentValidator = _stateManager.CurrentSnapshot.Validators
                 .GetValidatorsPublicKeys().Any(pk =>
@@ -136,7 +136,8 @@ namespace Lachain.Core.RPC.HTTP.FrontEnd
                 ["address"] = address,
                 ["publicKey"] = publicKey,
                 ["balance"] = balance.ToString(),
-                ["stake"] = stake.ToString(),
+                ["staked"] = staked.ToString(),
+                ["staking"] = staking.ToString(),
                 ["penalty"] = penalty.ToString(),
                 ["state"] = state,
                 ["online"] = isStaker,


### PR DESCRIPTION
`stake` field is removed and replaced with 2 fields: `staked` (amount delegated to this address as a stake) and `staking` (total amount delegated by this address as a stake)