### PR TITLE
added hash check before adding system transactions

### DIFF
--- a/src/Lachain.Core/Consensus/BlockProducer.cs
+++ b/src/Lachain.Core/Consensus/BlockProducer.cs
@@ -78,6 +78,10 @@ namespace Lachain.Core.Consensus
             // we don't need to verify receipts here
             // verfification will be done during emulation
 
+            // But we need to verify the hash as we map the receipts with its hash
+            // we skip the transactions with hash mismatch
+            receipts = receipts.Where(receipt => receipt.Transaction.FullHash(receipt.Signature).Equals(receipt.Hash)).ToList();
+
             receipts = receipts.OrderBy(receipt => receipt, new ReceiptComparer())
                 .ToList();
 


### PR DESCRIPTION
It's important to check hash validity of the transactions just after consensus. Because after that we use this hash to identify a transaction.