### PR TITLE
Improved transaction finality time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,6 +254,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+#VScode
+.vscode/
+
 PublishProfiles
 
 src/Lachain.Console/config.json

--- a/src/Lachain.Core/Blockchain/BlockchainConfig.cs
+++ b/src/Lachain.Core/Blockchain/BlockchainConfig.cs
@@ -6,5 +6,6 @@ namespace Lachain.Core.Blockchain
     {
         // targetBlockTime in miliseconds
         [JsonProperty("targetBlockTime")] public ulong TargetBlockTime;
+        [JsonProperty("targetTransactionsPerBlock")] public ulong TargetTransactionsPerBlock;
     }
 }

--- a/src/Lachain.Core/Blockchain/BlockchainConfig.cs
+++ b/src/Lachain.Core/Blockchain/BlockchainConfig.cs
@@ -6,6 +6,6 @@ namespace Lachain.Core.Blockchain
     {
         // targetBlockTime in miliseconds
         [JsonProperty("targetBlockTime")] public ulong TargetBlockTime;
-        [JsonProperty("targetTransactionsPerBlock")] public ulong TargetTransactionsPerBlock;
+        [JsonProperty("targetTransactionsPerBlock")] public int TargetTransactionsPerBlock;
     }
 }

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -445,15 +445,17 @@ namespace Lachain.Core.Config
         // and new blockchain.TargetTransactionsPerBlock (800) 
         private void _UpdateConfigToV16()
         {   
+            const int oldTargetBlockTime = 5000; //ms
             const int newTargetBlockTime = 4000; //ms
             const int newTargetTransactionsPerBlock = 800; 
 
             var blockchain = GetConfig<BlockchainConfig>("blockchain") ??
                             throw new ApplicationException("No blockchain section in config");
 
-            blockchain.TargetBlockTime = newTargetBlockTime;
-            blockchain.TargetTransactionsPerBlock = newTargetTransactionsPerBlock;
+            if (blockchain.TargetBlockTime == oldTargetBlockTime)
+                blockchain.TargetBlockTime = newTargetBlockTime;
 
+            blockchain.TargetTransactionsPerBlock = newTargetTransactionsPerBlock;
             _config["blockchain"] = JObject.FromObject(blockchain);
 
             var version = GetConfig<VersionConfig>("version") ??

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Lachain.Core.Blockchain;
 using Lachain.Core.Blockchain.Hardfork;
 using Lachain.Core.CLI;
 using Lachain.Networking;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Lachain.Core.Blockchain;
 
 
 namespace Lachain.Core.Config

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -445,11 +445,13 @@ namespace Lachain.Core.Config
         private void _UpdateConfigToV16()
         {   
             const int newTargetBlockTime = 4000; //ms
+            const int newTargetTransactionsPerBlock = 800; 
 
             var blockchain = GetConfig<BlockchainConfig>("blockchain") ??
                             throw new ApplicationException("No blockchain section in config");
 
             blockchain.TargetBlockTime = newTargetBlockTime;
+            blockchain.TargetTransactionsPerBlock = newTargetTransactionsPerBlock;
 
             _config["blockchain"] = JObject.FromObject(blockchain);
 

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -441,7 +441,8 @@ namespace Lachain.Core.Config
             _SaveCurrentConfig();
         }
 
-        // version 16 of config should contain cache option
+        // version 16 of config should contain updated blockchain.TargetBlockTime (4000 ms) 
+        // and new blockchain.TargetTransactionsPerBlock (800) 
         private void _UpdateConfigToV16()
         {   
             const int newTargetBlockTime = 4000; //ms

--- a/src/Lachain.Core/Consensus/BlockProducer.cs
+++ b/src/Lachain.Core/Consensus/BlockProducer.cs
@@ -66,7 +66,7 @@ namespace Lachain.Core.Consensus
             _blockManager = blockManager;
             _stateManager = stateManager;
             _transactionBuilder = transactionBuilder;
-            txPerBlock = Convert.ToInt32(configManager.GetConfig<BlockchainConfig>("blockchain")?.TargetTransactionsPerBlock ?? 1_000);
+            txPerBlock = configManager.GetConfig<BlockchainConfig>("blockchain")?.TargetTransactionsPerBlock ?? 1_000;
         }
 
         // Given an era, returns a proposed set of transaction receipts

--- a/src/Lachain.Core/Consensus/BlockProducer.cs
+++ b/src/Lachain.Core/Consensus/BlockProducer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Google.Protobuf;
 using Lachain.Logger;
 using Lachain.Consensus;
+using Lachain.Core.Blockchain;
 using Lachain.Core.Blockchain.Error;
 using Lachain.Core.Blockchain.Hardfork;
 using Lachain.Core.Blockchain.Interface;
@@ -13,13 +14,12 @@ using Lachain.Core.Blockchain.SystemContracts.ContractManager;
 using Lachain.Core.Blockchain.SystemContracts.Interface;
 using Lachain.Core.Blockchain.Validators;
 using Lachain.Core.Blockchain.VM;
+using Lachain.Core.Config;
 using Lachain.Core.Network;
 using Lachain.Crypto;
 using Lachain.Proto;
 using Lachain.Storage.State;
 using Lachain.Utility.Utils;
-using Lachain.Core.Config;
-using Lachain.Core.Blockchain;
 namespace Lachain.Core.Consensus
 {
     /*


### PR DESCRIPTION
Improved the txn finality time by decrease block time to 4 sec. To preserve tps, transactions per block was reduced to 800.

- Added `targetTransactionPerBlock` field in `BlockchainConfig`
- Implemented `_UpdateConfigToV16()`
- Used `targetTransactionPerBlock` from config instead of hardcoded value in `BlockProducer.cs`