### PR TITLE
Vault integration for wallet password

### DIFF
--- a/src/Lachain.Console/TrustedKeygen.cs
+++ b/src/Lachain.Console/TrustedKeygen.cs
@@ -157,6 +157,7 @@ namespace Lachain.Console
                 var walletPath = "wallet.json";
                 var vault = new VaultConfig
                 {
+                    UseVault = false,
                     Path = walletPath,
                     Password = getRandomPassword()
                 };
@@ -322,6 +323,7 @@ namespace Lachain.Console
                 var walletPath = "wallet.json";
                 var vault = new VaultConfig
                 {
+                    UseVault = false,
                     Path = walletPath,
                     Password = getRandomPassword()
                 };

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -18,8 +18,6 @@ namespace Lachain.Core.Config
         private IDictionary<string, object> _config;
         public string ConfigPath { get; }
         public RunOptions CommandLineOptions { get; }
-        
-
         public ConfigManager(string filePath, RunOptions options)
         {
             CommandLineOptions = options;
@@ -32,13 +30,13 @@ namespace Lachain.Core.Config
         public void UpdateWalletPassword(string password)
         {
             var vault = GetConfig<VaultConfig>("vault") ??
-                          throw new ApplicationException("No vault section in config");
+                        throw new ApplicationException("No vault section in config");
 
             if (vault.UseVault == true)
                 throw new ApplicationException("Vault is being used. Password cannot be written to config");
 
             vault.Password = password;
-            _config["vault"] = vault;
+            _config["vault"] = JObject.FromObject(vault);
             _SaveCurrentConfig();
         }
 
@@ -485,7 +483,5 @@ namespace Lachain.Core.Config
         {
             File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(_config, Formatting.Indented));
         }
-        
-        
     }
 }

--- a/src/Lachain.Core/Config/ConfigManager.cs
+++ b/src/Lachain.Core/Config/ConfigManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Lachain.Core.Blockchain;
 using Lachain.Core.Blockchain.Hardfork;
 using Lachain.Core.CLI;
+using Lachain.Core.Vault;
 using Lachain.Networking;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,6 +18,7 @@ namespace Lachain.Core.Config
         private IDictionary<string, object> _config;
         public string ConfigPath { get; }
         public RunOptions CommandLineOptions { get; }
+        
 
         public ConfigManager(string filePath, RunOptions options)
         {
@@ -25,6 +27,19 @@ namespace Lachain.Core.Config
             _config = new Dictionary<string, object>(configLoader.LoadConfig());
             ConfigPath = filePath;
             _UpdateConfigVersion();
+        }
+        
+        public void UpdateWalletPassword(string password)
+        {
+            var vault = GetConfig<VaultConfig>("vault") ??
+                          throw new ApplicationException("No vault section in config");
+
+            if (vault.UseVault == true)
+                throw new ApplicationException("Vault is being used. Password cannot be written to config");
+
+            vault.Password = password;
+            _config["vault"] = vault;
+            _SaveCurrentConfig();
         }
 
         public T? GetConfig<T>(string name)
@@ -470,5 +485,7 @@ namespace Lachain.Core.Config
         {
             File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(_config, Formatting.Indented));
         }
+        
+        
     }
 }

--- a/src/Lachain.Core/Config/IConfigManager.cs
+++ b/src/Lachain.Core/Config/IConfigManager.cs
@@ -9,5 +9,7 @@ namespace Lachain.Core.Config
         string ConfigPath { get; }
 
         RunOptions CommandLineOptions { get; }
+
+        void UpdateWalletPassword(string password);
     }
 }

--- a/src/Lachain.Core/Lachain.Core.csproj
+++ b/src/Lachain.Core/Lachain.Core.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Nethereum.Web3" Version="4.8.0" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="SimpleInjector" Version="5.1.0" />
+    <PackageReference Include="VaultSharp" Version="1.7.0" />
+
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\wasm\WebAssembly\WebAssembly.csproj" />

--- a/src/Lachain.Core/Vault/PrivateWallet.cs
+++ b/src/Lachain.Core/Vault/PrivateWallet.cs
@@ -48,7 +48,7 @@ namespace Lachain.Core.Vault
                          throw new Exception("No 'vault' section in config file");
 
             _walletPath = ReadWalletPath(configManager);
-            _walletPassword = ReadWalletPassword();
+            _walletPassword = _vaultConfig.ReadWalletPassword();
             
             _unlockEndTime = 0;
             if (!File.Exists(_walletPath))
@@ -273,41 +273,6 @@ namespace Lachain.Core.Vault
             }
             SaveWallet(_walletPath, _walletPassword);
             return true;
-        }
-
-        private string ReadWalletPassword()
-        {
-            if (_vaultConfig.UseVault == true)
-            {
-
-                var vaultAddress = _vaultConfig.VaultAddress ?? 
-                                    Environment.GetEnvironmentVariable("VAULT_ADDR") ??
-                                    throw new ArgumentNullException(nameof(_vaultConfig.VaultAddress));
-                
-                var vaultToken = _vaultConfig.VaultToken ?? 
-                                 Environment.GetEnvironmentVariable("VAULT_TOKEN") ??
-                                 throw new ArgumentNullException(nameof(_vaultConfig.VaultToken));
-                
-                var vaultMountpoint = _vaultConfig.VaultMountpoint ?? 
-                                 throw new ArgumentNullException(nameof(_vaultConfig.VaultMountpoint));
-                
-                var vaultEndpoint = _vaultConfig.VaultEndpoint ?? 
-                                      throw new ArgumentNullException(nameof(_vaultConfig.VaultEndpoint));
-
-                IAuthMethodInfo authMethod = new TokenAuthMethodInfo(vaultToken);
-                VaultClientSettings vaultClientSettings = new VaultClientSettings(vaultAddress, authMethod);
-                IVaultClient vaultClient = new VaultClient(vaultClientSettings);
-
-                Secret<SecretData> secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(
-                    path: vaultEndpoint,
-                    mountPoint: vaultMountpoint
-                ).Result;
-                return (string) secret.Data.Data["password"];
-            }
-            else 
-            {
-                return _vaultConfig.Password ?? throw new ArgumentNullException(nameof(_vaultConfig.Password));
-            }
         }
 
         private string ReadWalletPath(IConfigManager configManager)

--- a/src/Lachain.Core/Vault/VaultConfig.cs
+++ b/src/Lachain.Core/Vault/VaultConfig.cs
@@ -5,8 +5,10 @@ namespace Lachain.Core.Vault
     public class VaultConfig
     {
         [JsonProperty("useVault")] public bool? UseVault { get; set; }
-        [JsonProperty("vaultPath")] public string? VaultPath { get; set; }
+        [JsonProperty("vaultAddress")] public string? VaultAddress { get; set; }
         [JsonProperty("vaultToken")] public string? VaultToken { get; set; }
+        [JsonProperty("vaultMountpoint")] public string? VaultMountpoint { get; set; }
+        [JsonProperty("vaultEndpoint")] public string? VaultEndpoint { get; set; }
         [JsonProperty("path")] public string? Path { get; set; }
         [JsonProperty("password")] public string? Password { get; set; }
     }

--- a/src/Lachain.Core/Vault/VaultConfig.cs
+++ b/src/Lachain.Core/Vault/VaultConfig.cs
@@ -1,4 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Token;
+using VaultSharp.V1.Commons;
 
 namespace Lachain.Core.Vault
 {
@@ -11,5 +16,41 @@ namespace Lachain.Core.Vault
         [JsonProperty("vaultEndpoint")] public string? VaultEndpoint { get; set; }
         [JsonProperty("path")] public string? Path { get; set; }
         [JsonProperty("password")] public string? Password { get; set; }
+        
+        
+        public string ReadWalletPassword()
+        {
+            if (UseVault == true)
+            {
+
+                var vaultAddress = VaultAddress ?? 
+                                   Environment.GetEnvironmentVariable("VAULT_ADDR") ??
+                                   throw new ArgumentNullException(nameof(VaultAddress));
+                
+                var vaultToken = VaultToken ?? 
+                                 Environment.GetEnvironmentVariable("VAULT_TOKEN") ??
+                                 throw new ArgumentNullException(nameof(VaultToken));
+                
+                var vaultMountpoint = VaultMountpoint ?? 
+                                      throw new ArgumentNullException(nameof(VaultMountpoint));
+                
+                var vaultEndpoint = VaultEndpoint ?? 
+                                    throw new ArgumentNullException(nameof(VaultEndpoint));
+
+                IAuthMethodInfo authMethod = new TokenAuthMethodInfo(vaultToken);
+                VaultClientSettings vaultClientSettings = new VaultClientSettings(vaultAddress, authMethod);
+                IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+
+                Secret<SecretData> secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(
+                    path: vaultEndpoint,
+                    mountPoint: vaultMountpoint
+                ).Result;
+                return (string) secret.Data.Data["password"];
+            }
+            else 
+            {
+                return Password ?? throw new ArgumentNullException(nameof(Password));
+            }
+        }
     }
 }

--- a/src/Lachain.Core/Vault/VaultConfig.cs
+++ b/src/Lachain.Core/Vault/VaultConfig.cs
@@ -4,6 +4,7 @@ namespace Lachain.Core.Vault
 {
     public class VaultConfig
     {
+        [JsonProperty("usevault")] public bool? UseVault { get; set; }
         [JsonProperty("path")] public string? Path { get; set; }
         [JsonProperty("password")] public string? Password { get; set; }
     }

--- a/src/Lachain.Core/Vault/VaultConfig.cs
+++ b/src/Lachain.Core/Vault/VaultConfig.cs
@@ -4,7 +4,9 @@ namespace Lachain.Core.Vault
 {
     public class VaultConfig
     {
-        [JsonProperty("usevault")] public bool? UseVault { get; set; }
+        [JsonProperty("useVault")] public bool? UseVault { get; set; }
+        [JsonProperty("vaultPath")] public string? VaultPath { get; set; }
+        [JsonProperty("vaultToken")] public string? VaultToken { get; set; }
         [JsonProperty("path")] public string? Path { get; set; }
         [JsonProperty("password")] public string? Password { get; set; }
     }

--- a/test/Lachain.CoreTest/RPC/HTTP/FrontEnd/FrontEndServiceTest.cs
+++ b/test/Lachain.CoreTest/RPC/HTTP/FrontEnd/FrontEndServiceTest.cs
@@ -90,7 +90,7 @@ namespace Lachain.CoreTest.RPC.HTTP.FrontEnd
         [Repeat(2)]
         public void Test_PasswordChange()
         {
-            var initialPassword = _configManager.GetConfig<VaultConfig>("vault")?.Password;
+            var initialPassword = _configManager.GetConfig<VaultConfig>("vault")?.ReadWalletPassword();
             var newPassword = "abcde";
             
             // Change wallet password

--- a/test/Lachain.CoreTest/RPC/HTTP/Web3/Web3BlockchainServiceTest.cs
+++ b/test/Lachain.CoreTest/RPC/HTTP/Web3/Web3BlockchainServiceTest.cs
@@ -1062,7 +1062,7 @@ namespace Lachain.CoreTest.RPC.HTTP.Web3
             if(unlock){
                 var config = _configManager.GetConfig<VaultConfig>("vault") ??
                          throw new Exception("No 'vault' section in config file");
-                password = config.Password!;
+                password = config.ReadWalletPassword();
                 Assert.AreEqual(true,_privateWallet.Unlock(password, time));
             }
             else{

--- a/test/Lachain.CoreTest/RPC/HTTP/Web3/Web3ValidatorServiceTest.cs
+++ b/test/Lachain.CoreTest/RPC/HTTP/Web3/Web3ValidatorServiceTest.cs
@@ -135,7 +135,7 @@ namespace Lachain.CoreTest.RPC.HTTP.Web3
             if(unlock){
                 var config = _configManager.GetConfig<VaultConfig>("vault") ??
                          throw new Exception("No 'vault' section in config file");
-                password = config.Password!;
+                password = config.ReadWalletPassword();
                 Assert.AreEqual(true,_privateWallet.Unlock(password, time));
             }
             else{


### PR DESCRIPTION
- Added new fields to `vaultConfig` 
  - `UseVault`: determines if vault will be used to store wallet password
  - `VaultAddress`: Address of the vault. Only used if `UseVault` is true. Will attempt to read `VAULT_ADDR` environment variable if `null` and `UseVault` is true.
  - `VaultToken`: Token to access the vault. Only used if `UseVault` is true. Will attempt to read `VAULT_TOKEN` environment variable if `null` and `UseVault` is true.
  - `VaultMountpoint`: Mountpoint` of vault. Only used if `UseVault` is true.
  - `VaultEndpoint`: Path of vault where password will be stored. Only used if `UseVault` is true.
  
- If `UseVault` is `true` is config, will attempt to read password from vault using above parameters.
- Otherwise, will attempt to read from `password` field in config. 
- Implemented `Change Password` for both cases.

  